### PR TITLE
Fix a "Undefined variable: €" error in Tests\JSMin\JSMinTest

### DIFF
--- a/tests/Tests/JSMin/JSMinTest.php
+++ b/tests/Tests/JSMin/JSMinTest.php
@@ -60,8 +60,8 @@ class JSMinTest extends \PHPUnit_Framework_TestCase {
             return;
         }
 
-        $input = "function(s) {  return /^[£$€?.]/.test(s); }";
-        $expected = "function(s){return /^[£$€?.]/.test(s);}";
+        $input = 'function(s) {  return /^[£$€?.]/.test(s); }';
+        $expected = 'function(s){return /^[£$€?.]/.test(s);}';
         $this->assertEquals($expected, JSMin::minify($input));
     }
 


### PR DESCRIPTION
Hi!

Please fix the test implementation. The $ is evaluated as variable in double-apostroph (") php context. Either, single apostroph should be used (as in the patch) or the $ needs to be escaped, please.

Thanks.
