### PR TITLE
also exclude es6 template literals from WS removal

### DIFF
--- a/src/JSMin/JSMin.php
+++ b/src/JSMin/JSMin.php
@@ -196,7 +196,7 @@ class JSMin {
                 // fallthrough intentional
             case self::ACTION_DELETE_A: // 2
                 $this->a = $this->b;
-                if ($this->a === "'" || $this->a === '"') { // string literal
+                if ($this->a === "'" || $this->a === '"' || $this->a === "`") { // string or template literal
                     $str = $this->a; // in case needed for exception
                     for(;;) {
                         $this->output .= $this->a;


### PR DESCRIPTION
Spaces in [ES6 template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals) should not be removed. Bug mentioned and example JS provided in [this Autoptimize support ticket](https://wordpress.org/support/topic/es6-template-string-error). This obviously also impacts Minify.
