### PR TITLE
Preserve ES6 template literals

### DIFF
--- a/src/JSMin/JSMin.php
+++ b/src/JSMin/JSMin.php
@@ -196,7 +196,8 @@ class JSMin {
                 // fallthrough intentional
             case self::ACTION_DELETE_A: // 2
                 $this->a = $this->b;
-                if ($this->a === "'" || $this->a === '"') { // string literal
+                if ($this->a === "'" || $this->a === '"' || $this->a === '`') { // string/template literal
+                    $delimiter = $this->a;
                     $str = $this->a; // in case needed for exception
                     for(;;) {
                         $this->output .= $this->a;
@@ -206,7 +207,9 @@ class JSMin {
                         if ($this->a === $this->b) { // end quote
                             break;
                         }
-                        if ($this->isEOF($this->a)) {
+                        if ($delimiter === '`' && $this->a === "\n") {
+                            // leave the newline
+                        } elseif ($this->isEOF($this->a)) {
                             $byte = $this->inputIndex - 1;
                             throw new UnterminatedStringException(
                                 "JSMin: Unterminated String at byte {$byte}: {$str}");
@@ -216,7 +219,7 @@ class JSMin {
                             $this->output .= $this->a;
                             $this->lastByteOut = $this->a;
 
-                            $this->a       = $this->get();
+                            $this->a = $this->get();
                             $str .= $this->a;
                         }
                     }

--- a/tests/Resources/minify/expected/es6-literal.js
+++ b/tests/Resources/minify/expected/es6-literal.js
@@ -1,0 +1,2 @@
+`line
+break`+`he  llo`;foo`hel( '');lo`;`he\nl\`lo`;(`he${one + two}`)

--- a/tests/Resources/minify/input/es6-literal.js
+++ b/tests/Resources/minify/input/es6-literal.js
@@ -1,0 +1,2 @@
+`line
+break` + `he  llo`; foo`hel( '');lo`; `he\nl\`lo`; (`he${one + two}`)


### PR DESCRIPTION
We don't bother trying to remove whitespace in embedded expressions.
- https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals
- http://es6-features.org/#CustomInterpolation
