### PR TITLE
Fix php 8.1 deprecation notice for ord(null)

### DIFF
--- a/src/JSMin/JSMin.php
+++ b/src/JSMin/JSMin.php
@@ -335,7 +335,7 @@ class JSMin {
                 $c = null;
             }
         }
-        if (ord($c) >= self::ORD_SPACE || $c === "\n" || $c === null) {
+        if ($c === null || ord($c) >= self::ORD_SPACE || $c === "\n") {
             return $c;
         }
         if ($c === "\r") {


### PR DESCRIPTION
Avoid DEPRECIATED message with PHP8.1

 - PHP Deprecated: ord(): Passing null to parameter #1