### PR TITLE
Keep newline after string template

### DIFF
--- a/src/JSMin/JSMin.php
+++ b/src/JSMin/JSMin.php
@@ -143,7 +143,7 @@ class JSMin {
             } elseif (! $this->isAlphaNum($this->a)) {
                 if ($this->isWhiteSpace($this->b)
                     || ($this->isLineTerminator($this->b)
-                        && (false === strpos('}])+-"\'', $this->a)))) {
+                        && (false === strpos('}])+-"\'`', $this->a)))) {
                     $command = self::ACTION_DELETE_A_B;
                 }
             }

--- a/tests/Resources/minify/expected/es6-literal.js
+++ b/tests/Resources/minify/expected/es6-literal.js
@@ -1,2 +1,3 @@
 `line
-break`+`he  llo`;foo`hel( '');lo`;`he\nl\`lo`;(`he${one + two}`)
+break`+`he  llo`;foo`hel( '');lo`;`he\nl\`lo`;(`he${one + two}`)`hello`
+doSomething()

--- a/tests/Resources/minify/input/es6-literal.js
+++ b/tests/Resources/minify/input/es6-literal.js
@@ -1,2 +1,4 @@
 `line
 break` + `he  llo`; foo`hel( '');lo`; `he\nl\`lo`; (`he${one + two}`)
+`hello`
+doSomething()


### PR DESCRIPTION
Keep newline after string template. This addresses [issue #8.](https://github.com/mrclay/jsmin-php/issues/8).